### PR TITLE
Ensure PyTorch is installed with CUDA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--extra-index-url https://download.pytorch.org/whl/cu113
 torch>=1.1.0
 numpy>=0.13
 scipy>=1.2.0


### PR DESCRIPTION
This repo appears to require NVIDIA Apex, which requires PyTorch be installed with CUDA enabled. This change ensures that pip installs PyTorch with CUDA support.